### PR TITLE
Replace init script with one that actually works

### DIFF
--- a/sources/statsd-init.d
+++ b/sources/statsd-init.d
@@ -7,122 +7,76 @@
 # Default-Stop:      0 1 6
 ### END INIT INFO
 
-# Do NOT "set -e"
-
-# Source function library.
 . /etc/rc.d/init.d/functions
 
-# Source networking configuration.
-. /etc/sysconfig/network
+prog=statsd
+STATSDDIR=/usr/share/statsd
+statsd=./stats.js
+LOG=/var/log/statsd.log
+ERRLOG=/var/log/statsderr.log
+CONFFILE=/etc/statsd/config.js
+pidfile=/var/run/statsd.pid
+lockfile=/var/lock/subsys/statsd
+RETVAL=0
+STOP_TIMEOUT=${STOP_TIMEOUT-10}
 
-# Check that networking is up.
-[ "$NETWORKING" = "no" ] && exit 0
+start() {
+  echo -n $"Starting $prog: "
+  cd ${STATSDDIR}
 
-# For SELinux we need to use 'runuser' not 'su'
-SU="/bin/su"
+  # See if it's already running. Look *only* at the pid file.
+  if [ -f ${pidfile} ]; then
+    failure "PID file exists for statsd"
+    RETVAL=1
+  else
+    # Run as process
+    node ${statsd} ${CONFFILE} >> ${LOG} 2>> ${ERRLOG} &
+    RETVAL=$?
 
-PATH=$PATH:/usr/local/bin:/usr/bin:/bin
-NODE_BIN=$(which node||which nodejs)
+    # Store PID
+    echo $! > ${pidfile}
 
-if [ ! -x "$NODE_BIN" ]; then
-  echo "Can't find executable nodejs or node in PATH=$PATH"
-  exit 1
-fi
+    # Success
+    [ $RETVAL = 0 ] && success "statsd started"
+  fi
 
-NM=/usr/share
-S_BASE=${NM}/statsd
-LOG_DIR=/var/log
-RUN_DIR=/var/run
-
-# PATH should only include /usr/* if it runs after the mountnfs.sh script
-PATH=/sbin:/usr/sbin:/bin:/usr/bin
-DESC="StatsD"
-NAME=statsd
-DAEMON_ARGS="${S_BASE}/share/statsd/stats.js ${S_BASE}/etc/config.js 2>&1 >> ${LOG_DIR}/statsd.log "
-PIDFILE=${S_BASE}/var/run/$NAME.pid
-SCRIPTNAME=/etc/init.d/$NAME
-CHDIR="${S_BASE}/share/statsd"
-STATSD_USER=root
-
-# Exit if the package is not installed
-# [ -x "$DAEMON" ] || exit 0
-
-#
-# Function that starts the daemon/service
-#
-do_start()
-{
-        # Return
-        #   0 if daemon has been started
-        #   1 if daemon was already running
-        #   2 if daemon could not be started
-        daemon --user $STATSD_USER "exec node /usr/share/statsd/stats.js /etc/statsd/config.js  >> ${LOG_DIR}/statsd.log &"
-        # Add code here, if necessary, that waits for the process to be ready
-        # to handle requests from services started subsequently which depend
-        # on this one.  As a last resort, sleep for some time.
+  echo
+  return $RETVAL
 }
 
-#
-# Function that stops the daemon/service
-#
-do_stop()
-{
-        # Return
-        #   0 if daemon has been stopped
-        #   1 if daemon was already stopped
-        #   2 if daemon could not be stopped
-        #   other if a failure occurred
-        $SU - $STATSD_USER -c "pkill node"
-        RETVAL="$?"
-        [ "$RETVAL" = 2 ] && return 2
-        return "$RETVAL"
+stop() {
+  echo -n $"Stopping $prog: "
+  killproc -p ${pidfile}
+  RETVAL=$?
+  echo
+  [ $RETVAL = 0 ] && rm -f ${pidfile}
 }
 
-# Hack, hack, hack - nic
-alias log_daemon_msg=/bin/true
-alias log_end_msg=/bin/true
-
+# See how we were called.
 case "$1" in
   start)
-        [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
-        do_start
-        case "$?" in
-                0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-                2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-        esac
-        ;;
+  start
+  ;;
   stop)
-        [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
-        do_stop
-        case "$?" in
-                0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-                2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-        esac
-        ;;
-  restart|force-reload)
-        #
-        # If the "reload" option is implemented then remove the
-        # 'force-reload' alias
-        #
-        log_daemon_msg "Restarting $DESC" "$NAME"
-        do_stop
-        case "$?" in
-          0|1)
-                do_start
-                case "$?" in
-                        0) log_end_msg 0 ;;
-                        1) log_end_msg 1 ;; # Old process is still running
-                        *) log_end_msg 1 ;; # Failed to start
-                esac
-                ;;
-          *)
-                log_end_msg 1
-                ;;
-        esac
-        ;;
+  stop
+  ;;
+  status)
+  status -p ${pidfile} ${prog}
+  RETVAL=$?
+  ;;
+  restart)
+  stop
+  start
+  ;;
+  condrestart)
+  if [ -f ${pidfile} ] ; then
+    stop
+    start
+  fi
+  ;;
   *)
-        echo "Usage: $SCRIPTNAME {start|stop|restart|force-reload}" >&2
-        exit 3
-        ;;
+  echo $"Usage: $prog {start|stop|restart|condrestart|status}"
+  exit 1
 esac
 
+exit $RETVAL


### PR DESCRIPTION
Current statsd init script is broken.  Running ```sudo service statsd start``` on dev will show that spits out some error output.

This actually causes problems with salt highstate on new systems because the script also doesn't properly redirect streams, so a start never finishes and highstate hangs.